### PR TITLE
feat: Add sixel and iTerm image support

### DIFF
--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBitmap.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBitmap.java
@@ -1,0 +1,187 @@
+package com.termux.terminal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Rect;
+
+import android.os.SystemClock;
+
+/**
+ * A circular buffer of {@link TerminalRow}:s which keeps notes about what is visible on a logical screen and the scroll
+ * history.
+ * <p>
+ * See {@link #externalToInternalRow(int)} for how to map from logical screen rows to array indices.
+ */
+public class TerminalBitmap {
+    public Bitmap bitmap;
+    public int cellWidth;
+    public int cellHeight;
+    public int scrollLines;
+    public int[] cursorDelta;
+    private static final String LOG_TAG = "TerminalBitmap";
+
+
+    public TerminalBitmap(int num, WorkingTerminalBitmap sixel, int Y, int X, int cellW, int cellH, TerminalBuffer screen) {
+        Bitmap bm = sixel.bitmap;
+        bm = resizeBitmapConstraints(bm, sixel.width, sixel.height, cellW, cellH, screen.mColumns - X);
+        addBitmap(num, bm, Y, X, cellW, cellH, screen);
+    }
+
+    public TerminalBitmap(int num, byte[] image, int Y, int X, int cellW, int cellH, int width, int height, boolean aspect, TerminalBuffer screen) {
+        Bitmap bm = null;
+        int imageHeight;
+        int imageWidth;
+        int newWidth = width;
+        int newHeight = height;
+        if (height > 0 || width > 0) {
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inJustDecodeBounds = true;
+            try {
+                BitmapFactory.decodeByteArray(image, 0, image.length, options);
+            } catch (Exception e) {
+                Logger.logWarn(null, LOG_TAG, "Cannot decode image");
+            }
+            imageHeight = options.outHeight;
+            imageWidth = options.outWidth;
+            if (aspect) {
+                double wFactor = 9999.0;
+                double hFactor = 9999.0;
+                if (width > 0) {
+                    wFactor = (double)width / imageWidth;
+                }
+                if (height > 0) {
+                    hFactor = (double)height / imageHeight;
+                }
+                double factor = Math.min(wFactor, hFactor);
+                newWidth = (int)(factor * imageWidth);
+                newHeight = (int)(factor * imageHeight);
+            } else {
+                if (height <= 0) {
+                    newHeight = imageHeight;
+                }
+                if (width <= 0) {
+                    newWidth = imageWidth;
+                }
+            }
+            int scaleFactor = 1;
+            while (imageHeight >= 2 * newHeight * scaleFactor && imageWidth >= 2 * newWidth * scaleFactor) {
+                scaleFactor = scaleFactor * 2;
+            }
+            BitmapFactory.Options scaleOptions = new BitmapFactory.Options();
+            scaleOptions.inSampleSize = scaleFactor;
+            try {
+                bm = BitmapFactory.decodeByteArray(image, 0, image.length, scaleOptions);
+            } catch (Exception e) {
+                Logger.logWarn(null, LOG_TAG, "Out of memory, cannot decode image");
+                bitmap = null;
+                return;
+            }
+            if (bm == null) {
+                Logger.logWarn(null, LOG_TAG, "Could not decode image");
+                bitmap = null;
+                return;
+            }
+            int maxWidth = (screen.mColumns - X) * cellW;
+            if (newWidth > maxWidth) {
+                int cropWidth = bm.getWidth() * maxWidth / newWidth;
+                try {
+                    bm = Bitmap.createBitmap(bm, 0, 0, cropWidth, bm.getHeight());
+                    newWidth = maxWidth;
+                } catch(OutOfMemoryError e) {
+                    // This is just a memory optimization. If it fails,
+                    // continue (and probably fail later).
+                }
+            }
+            try {
+                bm = Bitmap.createScaledBitmap(bm, newWidth, newHeight, true);
+            } catch(OutOfMemoryError e) {
+                Logger.logWarn(null, LOG_TAG, "Out of memory, cannot rescale image");
+                bm = null;
+            }
+        } else {
+            try {
+                bm = BitmapFactory.decodeByteArray(image, 0, image.length);
+            } catch (OutOfMemoryError e) {
+                Logger.logWarn(null, LOG_TAG, "Out of memory, cannot decode image");
+            }
+        }
+
+        if (bm == null) {
+            Logger.logWarn(null, LOG_TAG, "Cannot decode image");
+            bitmap = null;
+            return;
+        }
+
+        bm = resizeBitmapConstraints(bm, bm.getWidth(), bm.getHeight(), cellW, cellH, screen.mColumns - X);
+        addBitmap(num, bm, Y, X, cellW, cellH, screen);
+        cursorDelta  = new int[] {scrollLines, (bitmap.getWidth() + cellW - 1) / cellW};
+    }
+
+    private void addBitmap(int num, Bitmap bm, int Y, int X, int cellW, int cellH, TerminalBuffer screen) {
+        if (bm == null) {
+            bitmap = null;
+            return;
+        }
+        int width = bm.getWidth();
+        int height = bm.getHeight();
+        cellWidth = cellW;
+        cellHeight = cellH;
+        int w = Math.min(screen.mColumns - X, (width + cellW - 1) / cellW);
+        int h = (height + cellH - 1) / cellH;
+        int s = 0;
+        for (int i=0; i<h; i++) {
+            if (Y+i-s == screen.mScreenRows) {
+                screen.scrollDownOneLine(0, screen.mScreenRows, TextStyle.NORMAL);
+                s++;
+            }
+            for (int j=0; j<w ; j++) {
+                screen.setChar(X+j, Y+i-s, '+', TextStyle.encodeBitmap(num, j, i));
+            }
+        }
+        if (w * cellW < width) {
+            try {
+                bm = Bitmap.createBitmap(bm, 0, 0, w * cellW, height);
+            } catch(OutOfMemoryError e) {
+                // Image cannot be cropped to only visible part due to out of memory.
+                // This causes memory waste.
+            } 
+        }
+        bitmap = bm;
+        scrollLines =  h - s;
+    }
+        
+    static public Bitmap resizeBitmap(Bitmap bm, int w, int h) {
+        int[] pixels = new int[bm.getAllocationByteCount()];
+        bm.getPixels(pixels, 0, bm.getWidth(), 0, 0, bm.getWidth(), bm.getHeight());
+        Bitmap newbm;
+        try {
+            newbm = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        } catch(OutOfMemoryError e) {
+            // Only a minor display glitch in this case
+            return bm;
+        }
+        int newWidth = Math.min(bm.getWidth(), w);
+        int newHeight = Math.min(bm.getHeight(), h);
+        newbm.setPixels(pixels, 0, bm.getWidth(), 0, 0, newWidth, newHeight);
+        return newbm;
+    }
+
+    static public Bitmap resizeBitmapConstraints(Bitmap bm, int w, int h, int cellW, int cellH, int Columns) {
+        // Width and height must be multiples of the cell width and height
+        // Bitmap should not extend beyonf screen width
+        if (w > cellW * Columns || (w % cellW) != 0 || (h % cellH) != 0) {
+            int newW = Math.min(cellW * Columns, ((w - 1) / cellW) * cellW + cellW);
+            int newH = ((h - 1) / cellH) * cellH + cellH;
+            try {
+                bm = resizeBitmap(bm, newW, newH);
+            } catch(OutOfMemoryError e) {
+                // Only a minor display glitch in this case
+            }
+        }
+        return bm;
+    }
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBitmap.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBitmap.java
@@ -155,7 +155,7 @@ public class TerminalBitmap {
     }
         
     static public Bitmap resizeBitmap(Bitmap bm, int w, int h) {
-        int[] pixels = new int[bm.getAllocationByteCount()];
+        int[] pixels = new int[bm.getWidth() * bm.getHeight()];
         bm.getPixels(pixels, 0, bm.getWidth(), 0, 0, bm.getWidth(), bm.getHeight());
         Bitmap newbm;
         try {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -541,15 +541,22 @@ public final class TerminalBuffer {
     }
 
     public Bitmap getSixelBitmap(int codePoint, long style) {
-        return bitmaps.get(TextStyle.bitmapNum(style)).bitmap;
+        TerminalBitmap terminalBitmap = bitmaps.get(TextStyle.bitmapNum(style));
+        if (terminalBitmap == null) {
+            return null;
+        }
+        return terminalBitmap.bitmap;
     }
 
-    public Rect getSixelRect(int codePoint, long style ) {
+    public void getSixelRect(long style, Rect out) {
         TerminalBitmap bm = bitmaps.get(TextStyle.bitmapNum(style));
+        if (bm == null) {
+            out.setEmpty();
+            return;
+        }
         int x = TextStyle.bitmapX(style);
         int y = TextStyle.bitmapY(style);
-        Rect r = new Rect(x * bm.cellWidth, y * bm.cellHeight, (x+1) * bm.cellWidth, (y+1) * bm.cellHeight);
-        return r;
+        out.set(x * bm.cellWidth, y * bm.cellHeight, (x + 1) * bm.cellWidth, (y + 1) * bm.cellHeight);
     }
 
     public void sixelStart(int width, int height) {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -1,6 +1,15 @@
 package com.termux.terminal;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.HashMap;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Rect;
+
+import android.os.SystemClock;
 
 /**
  * A circular buffer of {@link TerminalRow}:s which keeps notes about what is visible on a logical screen and the scroll
@@ -20,6 +29,12 @@ public final class TerminalBuffer {
     /** The index in the circular buffer where the visible screen starts. */
     private int mScreenFirstRow = 0;
 
+    public HashMap<Integer,TerminalBitmap> bitmaps;
+    public WorkingTerminalBitmap workingBitmap;
+    private boolean hasBitmaps;
+    private long bitmapLastGC;
+
+
     /**
      * Create a transcript screen.
      *
@@ -35,6 +50,9 @@ public final class TerminalBuffer {
         mLines = new TerminalRow[totalRows];
 
         blockSet(0, 0, columns, screenRows, ' ', TextStyle.NORMAL);
+        hasBitmaps = false;
+        bitmaps = new HashMap<Integer,TerminalBitmap>();
+        bitmapLastGC = SystemClock.uptimeMillis();
     }
 
     public String getTranscriptText() {
@@ -401,6 +419,28 @@ public final class TerminalBuffer {
         if (mLines[blankRow] == null) {
             mLines[blankRow] = new TerminalRow(mColumns, style);
         } else {
+            // find if a bitmap is completely scrolled out
+            Set<Integer> used = new HashSet<Integer>();
+            if(mLines[blankRow].mHasBitmap) {
+                for (int column = 0; column < mColumns; column++) {
+                    final long st = mLines[blankRow].getStyle(column);
+                    if (TextStyle.isBitmap(st)) {
+                        used.add((int)(st >> 16) & 0xffff);
+                    }
+                }
+                TerminalRow nextLine =  mLines[(blankRow + 1) % mTotalRows];
+                if(nextLine.mHasBitmap) {
+                    for (int column = 0; column < mColumns; column++) {
+                        final long st = nextLine.getStyle(column);
+                        if (TextStyle.isBitmap(st)) {
+                            used.remove((int)(st >> 16) & 0xffff);
+                        }
+                    }
+                }
+                for(Integer bm: used) {
+                    bitmaps.remove(bm);
+                }
+            }
             mLines[blankRow].clear(style);
         }
     }
@@ -439,9 +479,13 @@ public final class TerminalBuffer {
             throw new IllegalArgumentException(
                 "Illegal arguments! blockSet(" + sx + ", " + sy + ", " + w + ", " + h + ", " + val + ", " + mColumns + ", " + mScreenRows + ")");
         }
-        for (int y = 0; y < h; y++)
+        for (int y = 0; y < h; y++) {
             for (int x = 0; x < w; x++)
                 setChar(sx + x, sy + y, val, style);
+            if (sx+w == mColumns && val == ' ') {
+                clearLineWrap(sy + y);
+            }
+        }
     }
 
     public TerminalRow allocateFullLineIfNecessary(int row) {
@@ -492,6 +536,93 @@ public final class TerminalBuffer {
             Arrays.fill(mLines, mScreenFirstRow - mActiveTranscriptRows, mScreenFirstRow, null);
         }
         mActiveTranscriptRows = 0;
+        bitmaps.clear();
+        hasBitmaps = false;
+    }
+
+    public Bitmap getSixelBitmap(int codePoint, long style) {
+        return bitmaps.get(TextStyle.bitmapNum(style)).bitmap;
+    }
+
+    public Rect getSixelRect(int codePoint, long style ) {
+        TerminalBitmap bm = bitmaps.get(TextStyle.bitmapNum(style));
+        int x = TextStyle.bitmapX(style);
+        int y = TextStyle.bitmapY(style);
+        Rect r = new Rect(x * bm.cellWidth, y * bm.cellHeight, (x+1) * bm.cellWidth, (y+1) * bm.cellHeight);
+        return r;
+    }
+
+    public void sixelStart(int width, int height) {
+        workingBitmap = new WorkingTerminalBitmap(width, height);
+    }
+
+    public void sixelChar(int c, int rep) {
+        workingBitmap.sixelChar(c, rep);
+    }
+
+    public void sixelSetColor(int col) {
+        workingBitmap.sixelSetColor(col);
+    }
+
+    public void sixelSetColor(int col, int r, int g, int b) {
+        workingBitmap.sixelSetColor(col, r, g, b);
+    }
+
+    private int findFreeBitmap() {
+        int i = 0;
+        while (bitmaps.containsKey(i)) {
+            i++;
+        }
+        return i;
+    }
+
+    public int sixelEnd(int Y, int X, int cellW, int cellH) {
+        int num = findFreeBitmap();
+        bitmaps.put(num, new TerminalBitmap(num, workingBitmap, Y, X, cellW, cellH, this));
+        workingBitmap = null;
+        if (bitmaps.get(num).bitmap == null) {
+            bitmaps.remove(num);
+            return 0;
+        }
+        hasBitmaps = true;
+        bitmapGC(30000);
+        return bitmaps.get(num).scrollLines;
+    }
+
+    public int[] addImage(byte[] image, int Y, int X, int cellW, int cellH, int width, int height, boolean aspect) {
+        int num = findFreeBitmap();
+        bitmaps.put(num, new TerminalBitmap(num, image, Y, X, cellW, cellH, width, height, aspect, this));
+        if (bitmaps.get(num).bitmap == null) {
+            bitmaps.remove(num);
+            return new int[] {0,0};
+        }
+        hasBitmaps = true;
+        bitmapGC(30000);
+        return bitmaps.get(num).cursorDelta;
+    }
+
+    public void bitmapGC(int timeDelta) {
+        if (!hasBitmaps || bitmapLastGC + timeDelta > SystemClock.uptimeMillis()) {
+            return;
+        }
+        Set<Integer> used = new HashSet<Integer>();
+        for (int line = 0; line < mLines.length; line++) {
+            if(mLines[line] != null && mLines[line].mHasBitmap) {
+                for (int column = 0; column < mColumns; column++) {
+                    final long st = mLines[line].getStyle(column);
+                    if (TextStyle.isBitmap(st)) {
+                        used.add((int)(st >> 16) & 0xffff);
+                    }
+                }
+            }
+        }
+        Set<Integer> keys = new HashSet<Integer>(bitmaps.keySet());
+        for (Integer bn: keys) {
+            if (!used.contains(bn)) {
+                bitmaps.remove(bn);
+            }
+        }
+        bitmapLastGC = SystemClock.uptimeMillis();
     }
 
 }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalBuffer.java
@@ -429,7 +429,7 @@ public final class TerminalBuffer {
                     }
                 }
                 TerminalRow nextLine =  mLines[(blankRow + 1) % mTotalRows];
-                if(nextLine.mHasBitmap) {
+                if(nextLine != null && nextLine.mHasBitmap) {
                     for (int column = 0; column < mColumns; column++) {
                         final long st = nextLine.getStyle(column);
                         if (TextStyle.isBitmap(st)) {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -709,6 +709,162 @@ public final class TerminalEmulator {
                     case ESC_CSI_BIGGERTHAN:
                         doCsiBiggerThan(b);
                         break;
+                    case ESC_CSI_DOUBLE_QUOTE:
+                        if (b == 'q') {
+                            // http://www.vt100.net/docs/vt510-rm/DECSCA
+                            int arg = getArg0(0);
+                            if (arg == 0 || arg == 2) {
+                                // DECSED and DECSEL can erase characters.
+                                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
+                            } else if (arg == 1) {
+                                // DECSED and DECSEL cannot erase characters.
+                                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
+                            } else {
+                                unknownSequence(b);
+                            }
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_SINGLE_QUOTE:
+                        if (b == '}') { // Insert Ps Column(s) (default = 1) (DECIC), VT420 and up.
+                            int columnsAfterCursor = mRightMargin - mCursorCol;
+                            int columnsToInsert = Math.min(getArg0(1), columnsAfterCursor);
+                            int columnsToMove = columnsAfterCursor - columnsToInsert;
+                            mScreen.blockCopy(mCursorCol, 0, columnsToMove, mRows, mCursorCol + columnsToInsert, 0);
+                            blockClear(mCursorCol, 0, columnsToInsert, mRows);
+                        } else if (b == '~') { // Delete Ps Column(s) (default = 1) (DECDC), VT420 and up.
+                            int columnsAfterCursor = mRightMargin - mCursorCol;
+                            int columnsToDelete = Math.min(getArg0(1), columnsAfterCursor);
+                            int columnsToMove = columnsAfterCursor - columnsToDelete;
+                            mScreen.blockCopy(mCursorCol + columnsToDelete, 0, columnsToMove, mRows, mCursorCol, 0);
+                        } else {
+                            unknownSequence(b);
+                        }
+                        break;
+                    case ESC_CSI_DOLLAR:
+                        boolean originMode = isDecsetInternalBitSet(DECSET_BIT_ORIGIN_MODE);
+                        int effectiveTopMargin = originMode ? mTopMargin : 0;
+                        int effectiveBottomMargin = originMode ? mBottomMargin : mRows;
+                        int effectiveLeftMargin = originMode ? mLeftMargin : 0;
+                        int effectiveRightMargin = originMode ? mRightMargin : mColumns;
+                        switch (b) {
+                            case 'v': // ${CSI}${SRC_TOP}${SRC_LEFT}${SRC_BOTTOM}${SRC_RIGHT}${SRC_PAGE}${DST_TOP}${DST_LEFT}${DST_PAGE}$v"
+                                // Copy rectangular area (DECCRA - http://vt100.net/docs/vt510-rm/DECCRA):
+                                // "If Pbs is greater than Pts, or Pls is greater than Prs, the terminal ignores DECCRA.
+                                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
+                                // DECCRA is not affected by the page margins.
+                                // The copied text takes on the line attributes of the destination area.
+                                // If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, then the value
+                                // is treated as the width or height of that page.
+                                // If the destination area is partially off the page, then DECCRA clips the off-page data.
+                                // DECCRA does not change the active cursor position."
+                                int topSource = Math.min(getArg(0, 1, true) - 1 + effectiveTopMargin, mRows);
+                                int leftSource = Math.min(getArg(1, 1, true) - 1 + effectiveLeftMargin, mColumns);
+                                // Inclusive, so do not subtract one:
+                                int bottomSource = Math.min(Math.max(getArg(2, mRows, true) + effectiveTopMargin, topSource), mRows);
+                                int rightSource = Math.min(Math.max(getArg(3, mColumns, true) + effectiveLeftMargin, leftSource), mColumns);
+                                // int sourcePage = getArg(4, 1, true);
+                                int destionationTop = Math.min(getArg(5, 1, true) - 1 + effectiveTopMargin, mRows);
+                                int destinationLeft = Math.min(getArg(6, 1, true) - 1 + effectiveLeftMargin, mColumns);
+                                // int destinationPage = getArg(7, 1, true);
+                                int heightToCopy = Math.min(mRows - destionationTop, bottomSource - topSource);
+                                int widthToCopy = Math.min(mColumns - destinationLeft, rightSource - leftSource);
+                                mScreen.blockCopy(leftSource, topSource, widthToCopy, heightToCopy, destinationLeft, destionationTop);
+                                break;
+                            case '{': // ${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${"
+                                // Selective erase rectangular area (DECSERA - http://www.vt100.net/docs/vt510-rm/DECSERA).
+                            case 'x': // ${CSI}${CHAR};${TOP}${LEFT}${BOTTOM}${RIGHT}$x"
+                                // Fill rectangular area (DECFRA - http://www.vt100.net/docs/vt510-rm/DECFRA).
+                            case 'z': // ${CSI}$${TOP}${LEFT}${BOTTOM}${RIGHT}$z"
+                                // Erase rectangular area (DECERA - http://www.vt100.net/docs/vt510-rm/DECERA).
+                                boolean erase = b != 'x';
+                                boolean selective = b == '{';
+                                // Only DECSERA keeps visual attributes, DECERA does not:
+                                boolean keepVisualAttributes = erase && selective;
+                                int argIndex = 0;
+                                int fillChar = erase ? ' ' : getArg(argIndex++, -1, true);
+                                // "Pch can be any value from 32 to 126 or from 160 to 255. If Pch is not in this range, then the
+                                // terminal ignores the DECFRA command":
+                                if ((fillChar >= 32 && fillChar <= 126) || (fillChar >= 160 && fillChar <= 255)) {
+                                    // "If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, the value
+                                    // is treated as the width or height of that page."
+                                    int top = Math.min(getArg(argIndex++, 1, true) + effectiveTopMargin, effectiveBottomMargin + 1);
+                                    int left = Math.min(getArg(argIndex++, 1, true) + effectiveLeftMargin, effectiveRightMargin + 1);
+                                    int bottom = Math.min(getArg(argIndex++, mRows, true) + effectiveTopMargin, effectiveBottomMargin);
+                                    int right = Math.min(getArg(argIndex, mColumns, true) + effectiveLeftMargin, effectiveRightMargin);
+                                    long style = getStyle();
+                                    for (int row = top - 1; row < bottom; row++)
+                                        for (int col = left - 1; col < right; col++)
+                                            if (!selective || (TextStyle.decodeEffect(mScreen.getStyleAt(row, col)) & TextStyle.CHARACTER_ATTRIBUTE_PROTECTED) == 0)
+                                                mScreen.setChar(col, row, fillChar, keepVisualAttributes ? mScreen.getStyleAt(row, col) : style);
+                                }
+                                break;
+                            case 'r': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$r"
+                                // Change attributes in rectangular area (DECCARA - http://vt100.net/docs/vt510-rm/DECCARA).
+                            case 't': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$t"
+                                // Reverse attributes in rectangular area (DECRARA - http://www.vt100.net/docs/vt510-rm/DECRARA).
+                                boolean reverse = b == 't';
+                                // FIXME: "coordinates of the rectangular area are affected by the setting of origin mode (DECOM)".
+                                int top = Math.min(getArg(0, 1, true) - 1, effectiveBottomMargin) + effectiveTopMargin;
+                                int left = Math.min(getArg(1, 1, true) - 1, effectiveRightMargin) + effectiveLeftMargin;
+                                int bottom = Math.min(getArg(2, mRows, true), effectiveBottomMargin) + effectiveTopMargin;
+                                int right = Math.min(getArg(3, mColumns, true), effectiveRightMargin) + effectiveLeftMargin;
+                                if (mArgIndex >= 4) {
+                                    if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
+                                    for (int i = 4; i <= mArgIndex; i++) {
+                                        int bits = 0;
+                                        boolean setOrClear = true; // True if setting, false if clearing.
+                                        switch (getArg(i, 0, false)) {
+                                            case 0: // Attributes off (no bold, no underline, no blink, positive image).
+                                                bits = (TextStyle.CHARACTER_ATTRIBUTE_BOLD | TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE | TextStyle.CHARACTER_ATTRIBUTE_BLINK
+                                                    | TextStyle.CHARACTER_ATTRIBUTE_INVERSE);
+                                                if (!reverse) setOrClear = false;
+                                                break;
+                                            case 1: // Bold.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
+                                                break;
+                                            case 4: // Underline.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                                                break;
+                                            case 5: // Blink.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+                                                break;
+                                            case 7: // Negative image.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+                                                break;
+                                            case 22: // No bold.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
+                                                setOrClear = false;
+                                                break;
+                                            case 24: // No underline.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
+                                                setOrClear = false;
+                                                break;
+                                            case 25: // No blink.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
+                                                setOrClear = false;
+                                                break;
+                                            case 27: // Positive image.
+                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
+                                                setOrClear = false;
+                                                break;
+                                        }
+                                        if (reverse && !setOrClear) {
+                                            // Reverse attributes in rectangular area ignores non-(1,4,5,7) bits.
+                                        } else {
+                                            mScreen.setOrClearEffect(bits, setOrClear, reverse, isDecsetInternalBitSet(DECSET_BIT_RECTANGULAR_CHANGEATTRIBUTE),
+                                                effectiveLeftMargin, effectiveRightMargin, top, left, bottom, right);
+                                        }
+                                    }
+                                } else {
+                                    // Do nothing.
+                                }
+                                break;
+                            default:
+                                unknownSequence(b);
+                        }
+                        break;
                     case ESC_PERCENT:
                         break;
                     case ESC_APC:

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -3,6 +3,7 @@ package com.termux.terminal;
 import android.util.Base64;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.Objects;
@@ -82,11 +83,7 @@ public final class TerminalEmulator {
     /** Escape processing: "ESC _" or Application Program Command (APC). */
     private static final int ESC_APC = 20;
     /** Escape processing: "ESC _" or Application Program Command (APC), followed by Escape. */
-    private static final int ESC_APC_ESCAPE = 21;
-    /** Escape processing: ESC [ <parameter bytes> */
-    private static final int ESC_CSI_UNSUPPORTED_PARAMETER_BYTE = 22;
-    /** Escape processing: ESC [ <parameter bytes> <intermediate bytes> */
-    private static final int ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE = 23;
+    private static final int ESC_APC_ESC = 21;
 
     /** The number of parameter arguments including colon separated sub-parameters. */
     private static final int MAX_ESCAPE_PARAMETERS = 32;
@@ -196,6 +193,11 @@ public final class TerminalEmulator {
 
     /** The current state of the escape sequence state machine. One of the ESC_* constants. */
     private int mEscapeState;
+    private boolean ESC_P_escape = false;
+    private boolean ESC_P_sixel = false;
+    private ArrayList<Byte> ESC_OSC_data;
+    private int ESC_OSC_colon = 0;
+    private boolean ESC_OSC_outofmem = false;
 
     private final SavedScreenState mSavedStateMain = new SavedScreenState();
     private final SavedScreenState mSavedStateAlt = new SavedScreenState();
@@ -272,6 +274,13 @@ public final class TerminalEmulator {
     public final TerminalColors mColors = new TerminalColors();
 
     private static final String LOG_TAG = "TerminalEmulator";
+
+    private int cellW = 12, cellH = 12;
+
+    public void setCellSize(int w, int h) {
+        cellW = w;
+        cellH = h;
+    }
 
     private boolean isDecsetInternalBitSet(int bit) {
         return (mCurrentDecSetFlags & bit) != 0;
@@ -572,19 +581,24 @@ public final class TerminalEmulator {
         if (mEscapeState == ESC_APC) {
             doApc(b);
             return;
-        } else if (mEscapeState == ESC_APC_ESCAPE) {
-            doApcEscape(b);
+        } else if (mEscapeState == ESC_APC_ESC) {
+            doApcEsc(b);
             return;
         }
 
+        mScreen.bitmapGC(300000);
         switch (b) {
             case 0: // Null character (NUL, ^@). Do nothing.
                 break;
             case 7: // Bell (BEL, ^G, \a). If in an OSC sequence, BEL may terminate a string; otherwise signal bell.
                 if (mEscapeState == ESC_OSC)
                     doOsc(b);
-                else
+                else {
+                    if (mEscapeState == ESC_APC) {
+                        doApc(b);
+                    }
                     mSession.onBell();
+                }
                 break;
             case 8: // Backspace (BS, ^H).
                 if (mLeftMargin == mCursorCol) {
@@ -611,10 +625,16 @@ public final class TerminalEmulator {
             case 10: // Line feed (LF, \n).
             case 11: // Vertical tab (VT, \v).
             case 12: // Form feed (FF, \f).
-                doLinefeed();
+                if((mEscapeState != ESC_P || !ESC_P_sixel) && ESC_OSC_colon <= 0) {
+                    // Ignore CR/LF inside sixels or iterm2 data
+                    doLinefeed();
+                }
                 break;
             case 13: // Carriage return (CR, \r).
-                setCursorCol(mLeftMargin);
+                if((mEscapeState != ESC_P || !ESC_P_sixel) && ESC_OSC_colon <= 0) {
+                    // Ignore CR/LF inside sixels or iterm2 data
+                    setCursorCol(mLeftMargin);
+                }
                 break;
             case 14: // Shift Out (Ctrl-N, SO) → Switch to Alternate Character Set. This invokes the G1 character set.
                 mUseLineDrawingUsesG0 = false;
@@ -634,9 +654,14 @@ public final class TerminalEmulator {
                 // Starts an escape sequence unless we're parsing a string
                 if (mEscapeState == ESC_P) {
                     // XXX: Ignore escape when reading device control sequence, since it may be part of string terminator.
+                    ESC_P_escape = true;
                     return;
                 } else if (mEscapeState != ESC_OSC) {
-                    startEscapeSequence();
+                    if (mEscapeState != ESC_APC) {
+                        startEscapeSequence();
+                    } else {
+                        doApc(b);
+                    }
                 } else {
                     doOsc(b);
                 }
@@ -679,163 +704,13 @@ public final class TerminalEmulator {
                     case ESC_CSI_BIGGERTHAN:
                         doCsiBiggerThan(b);
                         break;
-                    case ESC_CSI_DOLLAR:
-                        boolean originMode = isDecsetInternalBitSet(DECSET_BIT_ORIGIN_MODE);
-                        int effectiveTopMargin = originMode ? mTopMargin : 0;
-                        int effectiveBottomMargin = originMode ? mBottomMargin : mRows;
-                        int effectiveLeftMargin = originMode ? mLeftMargin : 0;
-                        int effectiveRightMargin = originMode ? mRightMargin : mColumns;
-                        switch (b) {
-                            case 'v': // ${CSI}${SRC_TOP}${SRC_LEFT}${SRC_BOTTOM}${SRC_RIGHT}${SRC_PAGE}${DST_TOP}${DST_LEFT}${DST_PAGE}$v"
-                                // Copy rectangular area (DECCRA - http://vt100.net/docs/vt510-rm/DECCRA):
-                                // "If Pbs is greater than Pts, or Pls is greater than Prs, the terminal ignores DECCRA.
-                                // The coordinates of the rectangular area are affected by the setting of origin mode (DECOM).
-                                // DECCRA is not affected by the page margins.
-                                // The copied text takes on the line attributes of the destination area.
-                                // If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, then the value
-                                // is treated as the width or height of that page.
-                                // If the destination area is partially off the page, then DECCRA clips the off-page data.
-                                // DECCRA does not change the active cursor position."
-                                int topSource = Math.min(getArg(0, 1, true) - 1 + effectiveTopMargin, mRows);
-                                int leftSource = Math.min(getArg(1, 1, true) - 1 + effectiveLeftMargin, mColumns);
-                                // Inclusive, so do not subtract one:
-                                int bottomSource = Math.min(Math.max(getArg(2, mRows, true) + effectiveTopMargin, topSource), mRows);
-                                int rightSource = Math.min(Math.max(getArg(3, mColumns, true) + effectiveLeftMargin, leftSource), mColumns);
-                                // int sourcePage = getArg(4, 1, true);
-                                int destionationTop = Math.min(getArg(5, 1, true) - 1 + effectiveTopMargin, mRows);
-                                int destinationLeft = Math.min(getArg(6, 1, true) - 1 + effectiveLeftMargin, mColumns);
-                                // int destinationPage = getArg(7, 1, true);
-                                int heightToCopy = Math.min(mRows - destionationTop, bottomSource - topSource);
-                                int widthToCopy = Math.min(mColumns - destinationLeft, rightSource - leftSource);
-                                mScreen.blockCopy(leftSource, topSource, widthToCopy, heightToCopy, destinationLeft, destionationTop);
-                                break;
-                            case '{': // ${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${"
-                                // Selective erase rectangular area (DECSERA - http://www.vt100.net/docs/vt510-rm/DECSERA).
-                            case 'x': // ${CSI}${CHAR};${TOP}${LEFT}${BOTTOM}${RIGHT}$x"
-                                // Fill rectangular area (DECFRA - http://www.vt100.net/docs/vt510-rm/DECFRA).
-                            case 'z': // ${CSI}$${TOP}${LEFT}${BOTTOM}${RIGHT}$z"
-                                // Erase rectangular area (DECERA - http://www.vt100.net/docs/vt510-rm/DECERA).
-                                boolean erase = b != 'x';
-                                boolean selective = b == '{';
-                                // Only DECSERA keeps visual attributes, DECERA does not:
-                                boolean keepVisualAttributes = erase && selective;
-                                int argIndex = 0;
-                                int fillChar = erase ? ' ' : getArg(argIndex++, -1, true);
-                                // "Pch can be any value from 32 to 126 or from 160 to 255. If Pch is not in this range, then the
-                                // terminal ignores the DECFRA command":
-                                if ((fillChar >= 32 && fillChar <= 126) || (fillChar >= 160 && fillChar <= 255)) {
-                                    // "If the value of Pt, Pl, Pb, or Pr exceeds the width or height of the active page, the value
-                                    // is treated as the width or height of that page."
-                                    int top = Math.min(getArg(argIndex++, 1, true) + effectiveTopMargin, effectiveBottomMargin + 1);
-                                    int left = Math.min(getArg(argIndex++, 1, true) + effectiveLeftMargin, effectiveRightMargin + 1);
-                                    int bottom = Math.min(getArg(argIndex++, mRows, true) + effectiveTopMargin, effectiveBottomMargin);
-                                    int right = Math.min(getArg(argIndex, mColumns, true) + effectiveLeftMargin, effectiveRightMargin);
-                                    long style = getStyle();
-                                    for (int row = top - 1; row < bottom; row++)
-                                        for (int col = left - 1; col < right; col++)
-                                            if (!selective || (TextStyle.decodeEffect(mScreen.getStyleAt(row, col)) & TextStyle.CHARACTER_ATTRIBUTE_PROTECTED) == 0)
-                                                mScreen.setChar(col, row, fillChar, keepVisualAttributes ? mScreen.getStyleAt(row, col) : style);
-                                }
-                                break;
-                            case 'r': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$r"
-                                // Change attributes in rectangular area (DECCARA - http://vt100.net/docs/vt510-rm/DECCARA).
-                            case 't': // "${CSI}${TOP}${LEFT}${BOTTOM}${RIGHT}${ATTRIBUTES}$t"
-                                // Reverse attributes in rectangular area (DECRARA - http://www.vt100.net/docs/vt510-rm/DECRARA).
-                                boolean reverse = b == 't';
-                                // FIXME: "coordinates of the rectangular area are affected by the setting of origin mode (DECOM)".
-                                int top = Math.min(getArg(0, 1, true) - 1, effectiveBottomMargin) + effectiveTopMargin;
-                                int left = Math.min(getArg(1, 1, true) - 1, effectiveRightMargin) + effectiveLeftMargin;
-                                int bottom = Math.min(getArg(2, mRows, true) + 1, effectiveBottomMargin - 1) + effectiveTopMargin;
-                                int right = Math.min(getArg(3, mColumns, true) + 1, effectiveRightMargin - 1) + effectiveLeftMargin;
-                                if (mArgIndex >= 4) {
-                                    if (mArgIndex >= mArgs.length) mArgIndex = mArgs.length - 1;
-                                    for (int i = 4; i <= mArgIndex; i++) {
-                                        int bits = 0;
-                                        boolean setOrClear = true; // True if setting, false if clearing.
-                                        switch (getArg(i, 0, false)) {
-                                            case 0: // Attributes off (no bold, no underline, no blink, positive image).
-                                                bits = (TextStyle.CHARACTER_ATTRIBUTE_BOLD | TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE | TextStyle.CHARACTER_ATTRIBUTE_BLINK
-                                                    | TextStyle.CHARACTER_ATTRIBUTE_INVERSE);
-                                                if (!reverse) setOrClear = false;
-                                                break;
-                                            case 1: // Bold.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
-                                                break;
-                                            case 4: // Underline.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
-                                                break;
-                                            case 5: // Blink.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
-                                                break;
-                                            case 7: // Negative image.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
-                                                break;
-                                            case 22: // No bold.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BOLD;
-                                                setOrClear = false;
-                                                break;
-                                            case 24: // No underline.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_UNDERLINE;
-                                                setOrClear = false;
-                                                break;
-                                            case 25: // No blink.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_BLINK;
-                                                setOrClear = false;
-                                                break;
-                                            case 27: // Positive image.
-                                                bits = TextStyle.CHARACTER_ATTRIBUTE_INVERSE;
-                                                setOrClear = false;
-                                                break;
-                                        }
-                                        if (reverse && !setOrClear) {
-                                            // Reverse attributes in rectangular area ignores non-(1,4,5,7) bits.
-                                        } else {
-                                            mScreen.setOrClearEffect(bits, setOrClear, reverse, isDecsetInternalBitSet(DECSET_BIT_RECTANGULAR_CHANGEATTRIBUTE),
-                                                effectiveLeftMargin, effectiveRightMargin, top, left, bottom, right);
-                                        }
-                                    }
-                                } else {
-                                    // Do nothing.
-                                }
-                                break;
-                            default:
-                                unknownSequence(b);
-                        }
-                        break;
-                    case ESC_CSI_DOUBLE_QUOTE:
-                        if (b == 'q') {
-                            // http://www.vt100.net/docs/vt510-rm/DECSCA
-                            int arg = getArg0(0);
-                            if (arg == 0 || arg == 2) {
-                                // DECSED and DECSEL can erase characters.
-                                mEffect &= ~TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
-                            } else if (arg == 1) {
-                                // DECSED and DECSEL cannot erase characters.
-                                mEffect |= TextStyle.CHARACTER_ATTRIBUTE_PROTECTED;
-                            } else {
-                                unknownSequence(b);
-                            }
-                        } else {
-                            unknownSequence(b);
-                        }
-                        break;
-                    case ESC_CSI_SINGLE_QUOTE:
-                        if (b == '}') { // Insert Ps Column(s) (default = 1) (DECIC), VT420 and up.
-                            int columnsAfterCursor = mRightMargin - mCursorCol;
-                            int columnsToInsert = Math.min(getArg0(1), columnsAfterCursor);
-                            int columnsToMove = columnsAfterCursor - columnsToInsert;
-                            mScreen.blockCopy(mCursorCol, 0, columnsToMove, mRows, mCursorCol + columnsToInsert, 0);
-                            blockClear(mCursorCol, 0, columnsToInsert, mRows);
-                        } else if (b == '~') { // Delete Ps Column(s) (default = 1) (DECDC), VT420 and up.
-                            int columnsAfterCursor = mRightMargin - mCursorCol;
-                            int columnsToDelete = Math.min(getArg0(1), columnsAfterCursor);
-                            int columnsToMove = columnsAfterCursor - columnsToDelete;
-                            mScreen.blockCopy(mCursorCol + columnsToDelete, 0, columnsToMove, mRows, mCursorCol, 0);
-                        } else {
-                            unknownSequence(b);
-                        }
-                        break;
                     case ESC_PERCENT:
+                        break;
+                    case ESC_APC:
+                        doApc(b);
+                        break;
+                    case ESC_APC_ESC:
+                        doApcEsc(b);
                         break;
                     case ESC_OSC:
                         doOsc(b);
@@ -916,8 +791,17 @@ public final class TerminalEmulator {
 
     /** When in {@link #ESC_P} ("device control") sequence. */
     private void doDeviceControl(int b) {
-        switch (b) {
-            case (byte) '\\': // End of ESC \ string Terminator
+        boolean firstSixel = false;
+        if (!ESC_P_sixel && (b=='$' || b=='-' || b=='#')) {
+            //Check if sixel sequence that needs breaking
+            String dcs = mOSCOrDeviceControlArgs.toString();
+            if (dcs.matches("[0-9;]*q.*")) {
+                firstSixel = true;
+            }
+        }
+        if (firstSixel || (ESC_P_escape && b == '\\') || (ESC_P_sixel && (b=='$' || b=='-' || b=='#')))
+            // ESC \ terminates OSC
+            // Sixel sequences may be very long. '$' and '!' are natural for breaking the sequence.
             {
                 String dcs = mOSCOrDeviceControlArgs.toString();
                 // DCS $ q P t ST. Request Status String (DECRQSS)
@@ -1018,14 +902,102 @@ public final class TerminalEmulator {
                             Logger.logError(mClient, LOG_TAG, "Invalid device termcap/terminfo name of odd length: " + part);
                         }
                     }
+                } else if (ESC_P_sixel || dcs.matches("[0-9;]*q.*")) {
+                    int pos = 0;
+                    if (!ESC_P_sixel) {
+                        ESC_P_sixel = true;
+                        mScreen.sixelStart(100, 100);
+                        while (dcs.codePointAt(pos) != 'q') {
+                            pos++;
+                        }
+                        pos++;
+                    }
+                    if (b=='$' || b=='-') {
+                        // Add to string
+                        dcs = dcs + (char)b;
+                    }
+                    int rep = 1;
+                    while (pos < dcs.length()) {
+                        if (dcs.codePointAt(pos) == '"') {
+                            pos++;
+                            int args[]={0,0,0,0};
+                            int arg = 0;
+                            while (pos < dcs.length() && ((dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') || dcs.codePointAt(pos) == ';')) {
+                                if (dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') {
+                                    args[arg] = args[arg] * 10 + dcs.codePointAt(pos) - '0';
+                                } else {
+                                    arg++;
+                                    if (arg > 3) {
+                                        break;
+                                    }
+                                }
+                                pos++;
+                            }
+                            if (pos == dcs.length()) {
+                                break;
+                            }
+                        } else if (dcs.codePointAt(pos) == '#') {
+                            int col = 0;
+                            pos++;
+                            while (pos < dcs.length() && dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') {
+                                col = col * 10 + dcs.codePointAt(pos++) - '0';
+                            }
+                            if (pos == dcs.length() || dcs.codePointAt(pos) != ';') {
+                                mScreen.sixelSetColor(col);
+                            } else {
+                                pos++;
+                                int args[]={0,0,0,0};
+                                int arg = 0;
+                                while (pos < dcs.length() && ((dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') || dcs.codePointAt(pos) == ';')) {
+                                    if (dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') {
+                                        args[arg] = args[arg] * 10 + dcs.codePointAt(pos) - '0';
+                                    } else {
+                                        arg++;
+                                        if (arg > 3) {
+                                            break;
+                                        }
+                                    }
+                                    pos++;
+                                }
+                                if (args[0] == 2) {
+                                    mScreen.sixelSetColor(col, args[1], args[2], args[3]);
+                                }
+                            }
+                        } else if (dcs.codePointAt(pos) == '!') {
+                            rep = 0;
+                            pos++;
+                            while (pos < dcs.length() && dcs.codePointAt(pos) >= '0' && dcs.codePointAt(pos) <= '9') {
+                                rep = rep * 10 + dcs.codePointAt(pos++) - '0';
+                            }
+                        } else if (dcs.codePointAt(pos) == '$' || dcs.codePointAt(pos) == '-' || (dcs.codePointAt(pos) >= '?' && dcs.codePointAt(pos) <= '~')) {
+                            mScreen.sixelChar(dcs.codePointAt(pos++), rep);
+                            rep = 1;
+                        } else {
+                            pos++;
+                        }
+                    }
+                    if (b == '\\') {
+                        ESC_P_sixel = false;
+                        int n = mScreen.sixelEnd(mCursorRow, mCursorCol, cellW, cellH);
+                        for(;n>0;n--) {
+                            doLinefeed();
+                        }
+                    } else {
+                        mOSCOrDeviceControlArgs.setLength(0);
+                        if (b=='#') {
+                            mOSCOrDeviceControlArgs.appendCodePoint(b);
+                        }
+                        // Do not finish sequence
+                        continueSequence(mEscapeState);
+                        return;
+                    }
                 } else {
                     if (LOG_ESCAPE_SEQUENCES)
                         Logger.logError(mClient, LOG_TAG, "Unrecognized device control string: " + dcs);
                 }
                 finishSequence();
-            }
-            break;
-            default:
+            } else {
+                ESC_P_escape = false;
                 if (mOSCOrDeviceControlArgs.length() > MAX_OSC_STRING_LENGTH) {
                     // Too long.
                     mOSCOrDeviceControlArgs.setLength(0);
@@ -1034,31 +1006,7 @@ public final class TerminalEmulator {
                     mOSCOrDeviceControlArgs.appendCodePoint(b);
                     continueSequence(mEscapeState);
                 }
-        }
-    }
-
-    /**
-     * When in {@link #ESC_APC} (APC, Application Program Command) sequence.
-     */
-    private void doApc(int b) {
-        if (b == 27) {
-            continueSequence(ESC_APC_ESCAPE);
-        }
-        // Eat APC sequences silently for now.
-    }
-
-    /**
-     * When in {@link #ESC_APC} (APC, Application Program Command) sequence.
-     */
-    private void doApcEscape(int b) {
-        if (b == '\\') {
-            // A String Terminator (ST), ending the APC escape sequence.
-            finishSequence();
-        } else {
-            // The Escape character was not the start of a String Terminator (ST),
-            // but instead just data inside of the APC escape sequence.
-            continueSequence(ESC_APC);
-        }
+            }
     }
 
     private int nextTabStop(int numTabs) {
@@ -1473,6 +1421,7 @@ public final class TerminalEmulator {
                 break;
             case 'P': // Device control string
                 mOSCOrDeviceControlArgs.setLength(0);
+                ESC_P_escape = false;
                 continueSequence(ESC_P);
                 break;
             case '[':
@@ -1484,11 +1433,13 @@ public final class TerminalEmulator {
             case ']': // OSC
                 mOSCOrDeviceControlArgs.setLength(0);
                 continueSequence(ESC_OSC);
+                ESC_OSC_colon = -1;
                 break;
             case '>': // DECKPNM
                 setDecsetinternalBit(DECSET_BIT_APPLICATION_KEYPAD, false);
                 break;
             case '_': // APC - Application Program Command.
+                mOSCOrDeviceControlArgs.setLength(0);
                 continueSequence(ESC_APC);
                 break;
             default:
@@ -1717,7 +1668,7 @@ public final class TerminalEmulator {
                 // The important part that may still be used by some (tmux stores this value but does not currently use it)
                 // is the first response parameter identifying the terminal service class, where we send 64 for "vt420".
                 // This is followed by a list of attributes which is probably unused by applications. Send like xterm.
-                if (getArg0(0) == 0) mSession.write("\033[?64;1;2;6;9;15;18;21;22c");
+                if (getArg0(0) == 0) mSession.write("\033[?64;1;2;4;6;9;15;18;21;22c");
                 break;
             case 'd': // ESC [ Pn d - Vert Position Absolute
                 setCursorRow(Math.min(Math.max(1, getArg0(1)), mRows) - 1);
@@ -1981,6 +1932,33 @@ public final class TerminalEmulator {
         }
     }
 
+    private void doApc(int b) {
+        switch (b) {
+            case 7: // Bell.
+                break;
+            case 27: // Escape.
+                continueSequence(ESC_APC_ESC);
+                break;
+            default:
+                collectOSCArgs(b);
+                continueSequence(ESC_OSC);
+        }
+    }
+
+    private void doApcEsc(int b) {
+        switch (b) {
+            case '\\':
+                break;
+            default:
+                // The ESC character was not followed by a \, so insert the ESC and
+                // the current character in arg buffer.
+                collectOSCArgs(27);
+                collectOSCArgs(b);
+                continueSequence(ESC_APC);
+                break;
+        }
+    }
+
     private void doOsc(int b) {
         switch (b) {
             case 7: // Bell.
@@ -1991,6 +1969,29 @@ public final class TerminalEmulator {
                 break;
             default:
                 collectOSCArgs(b);
+                if (ESC_OSC_colon == -1 && b == ':') {
+                    // Collect base64 data for OSC 1337
+                    ESC_OSC_colon = mOSCOrDeviceControlArgs.length();
+                    ESC_OSC_data = new ArrayList<Byte>(65536);
+                    ESC_OSC_outofmem = false;
+                } else if (ESC_OSC_colon >= 0 && mOSCOrDeviceControlArgs.length() - ESC_OSC_colon == 4) {
+                    if (!ESC_OSC_outofmem) {
+                    try {
+                        byte[] decoded = Base64.decode(mOSCOrDeviceControlArgs.substring(ESC_OSC_colon), 0);
+                        for (int i = 0 ; i < decoded.length; i++) {
+                            ESC_OSC_data.add(decoded[i]);
+                        }
+                    } catch(Exception e) {
+                        // Ignore non-Base64 data.
+                    } catch(OutOfMemoryError e) {
+                        // Out of memory
+                        // Keep decoding, but fo not collect the data
+                        ESC_OSC_outofmem = true;
+                    }
+                    }
+                    mOSCOrDeviceControlArgs.setLength(ESC_OSC_colon);
+
+                }
                 break;
         }
     }
@@ -2013,6 +2014,8 @@ public final class TerminalEmulator {
     /** An Operating System Controls (OSC) Set Text Parameters. May come here from BEL or ST. */
     private void doOscSetTextParameters(String bellOrStringTerminator) {
         int value = -1;
+        int osc_colon = ESC_OSC_colon;
+        ESC_OSC_colon = -1;
         String textParameter = "";
         // Extract initial $value from initial "$value;..." string.
         for (int mOSCArgTokenizerIndex = 0; mOSCArgTokenizerIndex < mOSCOrDeviceControlArgs.length(); mOSCArgTokenizerIndex++) {
@@ -2147,6 +2150,105 @@ public final class TerminalEmulator {
                 mSession.onColorsChanged();
                 break;
             case 119: // Reset highlight color.
+                break;
+            case 1337: // iTerm extemsions
+                if (textParameter.startsWith("File=")) {
+                    int pos = 5;
+                    boolean inline = false;
+                    boolean aspect = true;
+                    int width = -1;
+                    int height = -1;
+                    while (pos < textParameter.length()) {
+                        int eqpos = textParameter.indexOf('=', pos);
+                        if (eqpos == -1) {
+                            break;
+                        }
+                        int semicolonpos = textParameter.indexOf(';', eqpos);
+                        if (semicolonpos == -1) {
+                            semicolonpos = textParameter.length() - 1;
+                        }
+                        String k = textParameter.substring(pos, eqpos);
+                        String v = textParameter.substring(eqpos + 1, semicolonpos);
+                        pos = semicolonpos + 1;
+                        if (k.equalsIgnoreCase("inline")) {
+                            inline = v.equals("1");
+                        }
+                        if (k.equalsIgnoreCase("preserveAspectRatio")) {
+                            aspect = ! v.equals("0");
+                        }
+                        if (k.equalsIgnoreCase("width")) {
+                            double factor = cellW;
+                            int div = 1;
+                            int e = v.length();
+                            if (v.endsWith("px")) {
+                                factor = 1;
+                                e -= 2;
+                            } else if (v.endsWith("%")) {
+                                factor = 0.01 * cellW * mColumns;
+                                e -= 1;
+                            }
+                            try {
+                                width = (int)(factor * Integer.parseInt(v.substring(0,e)));
+                            } catch(Exception ex) {
+                            }
+                        }
+                        if (k.equalsIgnoreCase("height")) {
+                            double factor = cellH;
+                            int div = 1;
+                            int e = v.length();
+                            if (v.endsWith("px")) {
+                                factor = 1;
+                                e -= 2;
+                            } else if (v.endsWith("%")) {
+                                factor = 0.01 * cellH * mRows;
+                                e -= 1;
+                            }
+                            try {
+                                height = (int)(factor * Integer.parseInt(v.substring(0,e)));
+                            } catch(Exception ex) {
+                            }
+                        }
+                    }
+                    if (!inline) {
+                        finishSequence();
+                        return;
+                    }
+                    if (osc_colon >= 0 && mOSCOrDeviceControlArgs.length() > osc_colon) {
+                        while (mOSCOrDeviceControlArgs.length() - osc_colon < 4) {
+                            mOSCOrDeviceControlArgs.append('=');
+                        }
+                        try {
+                            byte[] decoded = Base64.decode(mOSCOrDeviceControlArgs.substring(osc_colon), 0);
+                            for (int i = 0 ; i < decoded.length; i++) {
+                                ESC_OSC_data.add(decoded[i]);
+                            }
+                        } catch(Exception e) {
+                            // Ignore non-Base64 data.
+                        }
+                        mOSCOrDeviceControlArgs.setLength(osc_colon);
+                    }
+                    if (osc_colon >= 0) {
+                        byte[] result = new byte[ESC_OSC_data.size()];
+                        for(int i = 0; i < ESC_OSC_data.size(); i++) {
+                            result[i] = ESC_OSC_data.get(i).byteValue();
+                        }
+                        int[] res = mScreen.addImage(result, mCursorRow, mCursorCol, cellW, cellH, width, height, aspect);
+                        int col = res[1] + mCursorCol;
+                        if (col < mColumns -1) {
+                            res[0] -= 1;
+                        } else {
+                            col = 0;
+                        }
+                        for(;res[0] > 0; res[0]--) {
+                            doLinefeed();
+                        }
+                        mCursorCol = col;
+                        ESC_OSC_data.clear();
+                    } else {
+                    }
+                } else if (textParameter.startsWith("ReportCellSize")) {
+                    mSession.write(String.format(Locale.US, "\0331337;ReportCellSize=%d;%d\007", cellH, cellW));
+                }
                 break;
             default:
                 unknownParameter(value);
@@ -2565,6 +2667,10 @@ public final class TerminalEmulator {
 
         mColors.reset();
         mSession.onColorsChanged();
+
+        ESC_P_escape = false;
+        ESC_P_sixel = false;
+        ESC_OSC_colon = -1;
     }
 
     public String getSelectedText(int x1, int y1, int x2, int y2) {

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -2,6 +2,7 @@ package com.termux.terminal;
 
 import android.util.Base64;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,6 +85,10 @@ public final class TerminalEmulator {
     private static final int ESC_APC = 20;
     /** Escape processing: "ESC _" or Application Program Command (APC), followed by Escape. */
     private static final int ESC_APC_ESC = 21;
+    /** Escape processing: ESC [ <parameter bytes> */
+    private static final int ESC_CSI_UNSUPPORTED_PARAMETER_BYTE = 22;
+    /** Escape processing: ESC [ <parameter bytes> <intermediate bytes> */
+    private static final int ESC_CSI_UNSUPPORTED_INTERMEDIATE_BYTE = 23;
 
     /** The number of parameter arguments including colon separated sub-parameters. */
     private static final int MAX_ESCAPE_PARAMETERS = 32;
@@ -195,7 +200,7 @@ public final class TerminalEmulator {
     private int mEscapeState;
     private boolean ESC_P_escape = false;
     private boolean ESC_P_sixel = false;
-    private ArrayList<Byte> ESC_OSC_data;
+    private ByteArrayOutputStream ESC_OSC_data;
     private int ESC_OSC_colon = 0;
     private boolean ESC_OSC_outofmem = false;
 
@@ -1940,20 +1945,18 @@ public final class TerminalEmulator {
                 continueSequence(ESC_APC_ESC);
                 break;
             default:
-                collectOSCArgs(b);
-                continueSequence(ESC_OSC);
+                break;
         }
     }
 
     private void doApcEsc(int b) {
         switch (b) {
             case '\\':
+                finishSequence();
                 break;
             default:
                 // The ESC character was not followed by a \, so insert the ESC and
                 // the current character in arg buffer.
-                collectOSCArgs(27);
-                collectOSCArgs(b);
                 continueSequence(ESC_APC);
                 break;
         }
@@ -1972,15 +1975,13 @@ public final class TerminalEmulator {
                 if (ESC_OSC_colon == -1 && b == ':') {
                     // Collect base64 data for OSC 1337
                     ESC_OSC_colon = mOSCOrDeviceControlArgs.length();
-                    ESC_OSC_data = new ArrayList<Byte>(65536);
+                    ESC_OSC_data = new ByteArrayOutputStream();
                     ESC_OSC_outofmem = false;
                 } else if (ESC_OSC_colon >= 0 && mOSCOrDeviceControlArgs.length() - ESC_OSC_colon == 4) {
                     if (!ESC_OSC_outofmem) {
                     try {
                         byte[] decoded = Base64.decode(mOSCOrDeviceControlArgs.substring(ESC_OSC_colon), 0);
-                        for (int i = 0 ; i < decoded.length; i++) {
-                            ESC_OSC_data.add(decoded[i]);
-                        }
+                        ESC_OSC_data.write(decoded, 0, decoded.length);
                     } catch(Exception e) {
                         // Ignore non-Base64 data.
                     } catch(OutOfMemoryError e) {
@@ -2165,7 +2166,7 @@ public final class TerminalEmulator {
                         }
                         int semicolonpos = textParameter.indexOf(';', eqpos);
                         if (semicolonpos == -1) {
-                            semicolonpos = textParameter.length() - 1;
+                            semicolonpos = textParameter.length();
                         }
                         String k = textParameter.substring(pos, eqpos);
                         String v = textParameter.substring(eqpos + 1, semicolonpos);
@@ -2219,19 +2220,14 @@ public final class TerminalEmulator {
                         }
                         try {
                             byte[] decoded = Base64.decode(mOSCOrDeviceControlArgs.substring(osc_colon), 0);
-                            for (int i = 0 ; i < decoded.length; i++) {
-                                ESC_OSC_data.add(decoded[i]);
-                            }
+                            ESC_OSC_data.write(decoded, 0, decoded.length);
                         } catch(Exception e) {
                             // Ignore non-Base64 data.
                         }
                         mOSCOrDeviceControlArgs.setLength(osc_colon);
                     }
                     if (osc_colon >= 0) {
-                        byte[] result = new byte[ESC_OSC_data.size()];
-                        for(int i = 0; i < ESC_OSC_data.size(); i++) {
-                            result[i] = ESC_OSC_data.get(i).byteValue();
-                        }
+                        byte[] result = ESC_OSC_data.toByteArray();
                         int[] res = mScreen.addImage(result, mCursorRow, mCursorCol, cellW, cellH, width, height, aspect);
                         int col = res[1] + mCursorCol;
                         if (col < mColumns -1) {
@@ -2243,11 +2239,11 @@ public final class TerminalEmulator {
                             doLinefeed();
                         }
                         mCursorCol = col;
-                        ESC_OSC_data.clear();
+                        ESC_OSC_data = null;
                     } else {
                     }
                 } else if (textParameter.startsWith("ReportCellSize")) {
-                    mSession.write(String.format(Locale.US, "\0331337;ReportCellSize=%d;%d\007", cellH, cellW));
+                    mSession.write(String.format(Locale.US, "\033]1337;ReportCellSize=%d;%d\007", cellH, cellW));
                 }
                 break;
             default:

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -599,9 +599,6 @@ public final class TerminalEmulator {
                 if (mEscapeState == ESC_OSC)
                     doOsc(b);
                 else {
-                    if (mEscapeState == ESC_APC) {
-                        doApc(b);
-                    }
                     mSession.onBell();
                 }
                 break;
@@ -662,11 +659,7 @@ public final class TerminalEmulator {
                     ESC_P_escape = true;
                     return;
                 } else if (mEscapeState != ESC_OSC) {
-                    if (mEscapeState != ESC_APC) {
-                        startEscapeSequence();
-                    } else {
-                        doApc(b);
-                    }
+                    startEscapeSequence();
                 } else {
                     doOsc(b);
                 }
@@ -2096,6 +2089,8 @@ public final class TerminalEmulator {
     private void doApc(int b) {
         switch (b) {
             case 7: // Bell.
+                finishSequence();
+                mSession.onBell();
                 break;
             case 27: // Escape.
                 continueSequence(ESC_APC_ESC);
@@ -2335,7 +2330,6 @@ public final class TerminalEmulator {
                         }
                         if (k.equalsIgnoreCase("width")) {
                             double factor = cellW;
-                            int div = 1;
                             int e = v.length();
                             if (v.endsWith("px")) {
                                 factor = 1;
@@ -2351,7 +2345,6 @@ public final class TerminalEmulator {
                         }
                         if (k.equalsIgnoreCase("height")) {
                             double factor = cellH;
-                            int div = 1;
                             int e = v.length();
                             if (v.endsWith("px")) {
                                 factor = 1;

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalEmulator.java
@@ -2137,7 +2137,7 @@ public final class TerminalEmulator {
                         // Ignore non-Base64 data.
                     } catch(OutOfMemoryError e) {
                         // Out of memory
-                        // Keep decoding, but fo not collect the data
+                        // Keep decoding, but do not collect the data
                         ESC_OSC_outofmem = true;
                     }
                     }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
@@ -49,6 +49,8 @@ public final class TerminalRow {
     final long[] mStyle;
     /** If this row might contain chars with width != 1, used for deactivating fast path */
     boolean mHasNonOneWidthOrSurrogateChars;
+    /** If this row has a bitmap. Used for performace only */
+    public boolean mHasBitmap;
 
     /** Construct a blank row (containing only whitespace, ' ') with a specified style. */
     public TerminalRow(int columns, long style) {
@@ -146,6 +148,7 @@ public final class TerminalRow {
         Arrays.fill(mStyle, style);
         mSpaceUsed = (short) mColumns;
         mHasNonOneWidthOrSurrogateChars = false;
+        mHasBitmap = false;
     }
 
     // https://github.com/steven676/Android-Terminal-Emulator/commit/9a47042620bec87617f0b4f5d50568535668fe26
@@ -154,6 +157,10 @@ public final class TerminalRow {
             throw new IllegalArgumentException("TerminalRow.setChar(): columnToSet=" + columnToSet + ", codePoint=" + codePoint + ", style=" + style);
 
         mStyle[columnToSet] = style;
+
+        if (!mHasBitmap && TextStyle.isBitmap(style)) {
+            mHasBitmap = true;
+        }
 
         final int newCodePointDisplayWidth = WcWidth.width(codePoint);
 

--- a/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TerminalRow.java
@@ -49,7 +49,7 @@ public final class TerminalRow {
     final long[] mStyle;
     /** If this row might contain chars with width != 1, used for deactivating fast path */
     boolean mHasNonOneWidthOrSurrogateChars;
-    /** If this row has a bitmap. Used for performace only */
+    /** If this row has a bitmap. Used for performance only */
     public boolean mHasBitmap;
 
     /** Construct a blank row (containing only whitespace, ' ') with a specified style. */

--- a/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
@@ -35,6 +35,8 @@ public final class TextStyle {
     private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_FOREGROUND = 1 << 9;
     /** If true (24-bit) color is used for the cell for foreground. */
     private final static int CHARACTER_ATTRIBUTE_TRUECOLOR_BACKGROUND= 1 << 10;
+    /** If true, character represents a bitmap slice, not text. */
+    public final static int BITMAP = 1 << 15;
 
     public final static int COLOR_INDEX_FOREGROUND = 256;
     public final static int COLOR_INDEX_BACKGROUND = 257;
@@ -85,6 +87,26 @@ public final class TextStyle {
 
     public static int decodeEffect(long style) {
         return (int) (style & 0b11111111111);
+    }
+
+    public static long encodeBitmap(int num, int X, int Y) {
+        return ((long)num << 16) | ((long)Y << 32) | ((long)X << 48) | BITMAP;
+        }
+
+    public static boolean isBitmap(long style) {
+        return (style & 0x8000) != 0;
+    }
+
+    public static int bitmapNum(long style) {
+        return (int)(style & 0xffff0000) >> 16;
+    }
+
+    public static int bitmapX(long style) {
+        return (int)((style >> 48) & 0xfff);
+    }
+
+    public static int bitmapY(long style) {
+        return (int)((style >> 32) & 0xfff);
     }
 
 }

--- a/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/TextStyle.java
@@ -98,7 +98,7 @@ public final class TextStyle {
     }
 
     public static int bitmapNum(long style) {
-        return (int)(style & 0xffff0000) >> 16;
+        return (int) ((style >>> 16) & 0xFFFFL);
     }
 
     public static int bitmapX(long style) {

--- a/terminal-emulator/src/main/java/com/termux/terminal/WorkingTerminalBitmap.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/WorkingTerminalBitmap.java
@@ -1,0 +1,110 @@
+package com.termux.terminal;
+
+import android.graphics.Bitmap;
+
+/**
+ * A circular buffer of {@link TerminalRow}:s which keeps notes about what is visible on a logical screen and the scroll
+ * history.
+ * <p>
+ * See {@link #externalToInternalRow(int)} for how to map from logical screen rows to array indices.
+ */
+public final class WorkingTerminalBitmap {
+    final private int sixelInitialColorMap[] = {0xFF000000, 0xFF3333CC, 0xFFCC2323, 0xFF33CC33, 0xFFCC33CC, 0xFF33CCCC, 0xFFCCCC33, 0xFF777777,
+                                                0xFF444444, 0xFF565699, 0xFF994444, 0xFF569956, 0xFF995699, 0xFF569999, 0xFF999956, 0xFFCCCCCC};
+    private int[] colorMap;
+    private int curX;
+    private int curY;
+    private int color;
+    public int width;
+    public int height;
+    public Bitmap bitmap;
+    private static final String LOG_TAG = "WorkingTerminalBitmap";
+
+    public WorkingTerminalBitmap(int w, int h) {
+        try {
+            bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+        } catch (OutOfMemoryError e) {
+            Logger.logWarn(null, LOG_TAG, "Out of memory - sixel ignored");
+            bitmap = null;
+        }
+        bitmap.eraseColor(0);
+        width = 0;
+        height = 0;
+        curX = 0;
+        curY = 0;
+        colorMap = new int[256];
+        for (int i=0; i<16; i++) {
+            colorMap[i] = sixelInitialColorMap[i];
+        }
+        color = colorMap[0];
+    }
+
+    public void sixelChar(int c, int rep) {
+        if (bitmap == null) {
+            return;
+        }
+        if (c == '$') {
+            curX = 0;
+            return;
+        }
+        if (c == '-') {
+            curX = 0;
+            curY += 6;
+            return;
+        }
+        if (bitmap.getWidth() < curX + rep) {
+            try {
+                bitmap = TerminalBitmap.resizeBitmap(bitmap, curX + rep + 100, bitmap.getHeight());
+            } catch(OutOfMemoryError e) {
+                Logger.logWarn(null, LOG_TAG, "Out of memory - sixel truncated");
+            }
+        }
+        if (bitmap.getHeight() < curY + 6) {
+            // Very unlikely to resize both at the same time
+            try {
+                bitmap = TerminalBitmap.resizeBitmap(bitmap, bitmap.getWidth(), curY + 100);
+            } catch(OutOfMemoryError e) {
+                Logger.logWarn(null, LOG_TAG, "Out of memory - sixel truncated");
+            }
+        }
+        if (curX + rep > bitmap.getWidth()) {
+            rep = bitmap.getWidth() - curX;
+        }
+        if ( curY + 6 > bitmap.getHeight()) {
+            return;
+        }
+        if (rep > 0 && c >= '?' && c <= '~') {
+            int b = c - '?';
+            if (curY + 6 > height) {
+                height = curY + 6;
+            }
+            while (rep-- > 0) {
+                for (int i = 0 ; i < 6 ; i++) {
+                    if ((b & (1<<i)) != 0) {
+                        bitmap.setPixel(curX, curY + i, color);
+                    }
+                }
+                curX += 1;
+                if (curX > width) {
+                    width = curX;
+                }
+            }
+        }
+    }
+
+    public void sixelSetColor(int col) {
+        if (col >= 0 && col < 256) {
+            color = colorMap[col];
+        }
+    }
+
+    public void sixelSetColor(int col, int r, int g, int b) {
+        if (col >= 0 && col < 256) {
+            int red = Math.min(255, r*255/100);
+            int green = Math.min(255, g*255/100);
+            int blue = Math.min(255, b*255/100);
+            color = 0xff000000 + (red << 16) + (green << 8) + blue;
+            colorMap[col] = color;
+        }
+    }
+}

--- a/terminal-emulator/src/main/java/com/termux/terminal/WorkingTerminalBitmap.java
+++ b/terminal-emulator/src/main/java/com/termux/terminal/WorkingTerminalBitmap.java
@@ -27,7 +27,9 @@ public final class WorkingTerminalBitmap {
             Logger.logWarn(null, LOG_TAG, "Out of memory - sixel ignored");
             bitmap = null;
         }
-        bitmap.eraseColor(0);
+        if (bitmap != null) {
+            bitmap.eraseColor(0);
+        }
         width = 0;
         height = 0;
         curX = 0;

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -1,8 +1,11 @@
 package com.termux.view;
 
+import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.PorterDuff;
+import android.graphics.Rect;
+import android.graphics.RectF;
 import android.graphics.Typeface;
 
 import com.termux.terminal.TerminalBuffer;
@@ -65,6 +68,7 @@ public final class TerminalRenderer {
         final TerminalBuffer screen = mEmulator.getScreen();
         final int[] palette = mEmulator.mColors.mCurrentColors;
         final int cursorShape = mEmulator.getCursorStyle();
+        mEmulator.setCellSize((int)mFontWidth, (int)mFontLineSpacing);
 
         if (reverseVideo)
             canvas.drawColor(palette[TextStyle.COLOR_INDEX_FOREGROUND], PorterDuff.Mode.SRC);
@@ -98,10 +102,28 @@ public final class TerminalRenderer {
                 final boolean charIsHighsurrogate = Character.isHighSurrogate(charAtIndex);
                 final int charsForCodePoint = charIsHighsurrogate ? 2 : 1;
                 final int codePoint = charIsHighsurrogate ? Character.toCodePoint(charAtIndex, line[currentCharIndex + 1]) : charAtIndex;
+                final long style = lineObject.getStyle(column);
+                if (TextStyle.isBitmap(style)) {
+                    Bitmap bm = mEmulator.getScreen().getSixelBitmap(codePoint, style);
+                    if (bm != null) {
+                        float left = column * mFontWidth;
+                        float top = heightOffset - mFontLineSpacing;
+                        RectF r = new RectF(left, top, left + mFontWidth, top + mFontLineSpacing);
+                        canvas.drawBitmap(mEmulator.getScreen().getSixelBitmap(codePoint, style), mEmulator.getScreen().getSixelRect(codePoint, style), r, null);
+                    }
+                    column += 1;
+                    measuredWidthForRun = 0.f;
+                    lastRunStyle = 0;
+                    lastRunInsideCursor = false;
+                    lastRunStartColumn = column + 1;
+                    lastRunStartIndex = currentCharIndex;
+                    lastRunFontWidthMismatch = false;
+                    currentCharIndex += charsForCodePoint;
+                    continue;
+                }
                 final int codePointWcWidth = WcWidth.width(codePoint);
                 final boolean insideCursor = (cursorX == column || (codePointWcWidth == 2 && cursorX == column + 1));
                 final boolean insideSelection = column >= selx1 && column <= selx2;
-                final long style = lineObject.getStyle(column);
 
                 // Check if the measured text width for this code point is not the same as that expected by wcwidth().
                 // This could happen for some fonts which are not truly monospace, or for more exotic characters such as
@@ -112,7 +134,7 @@ public final class TerminalRenderer {
                 final boolean fontWidthMismatch = Math.abs(measuredCodePointWidth / mFontWidth - codePointWcWidth) > 0.01;
 
                 if (style != lastRunStyle || insideCursor != lastRunInsideCursor || insideSelection != lastRunInsideSelection || fontWidthMismatch || lastRunFontWidthMismatch) {
-                    if (column == 0) {
+                    if (column == 0 || column == lastRunStartColumn) {
                         // Skip first column as there is nothing to draw, just record the current style.
                     } else {
                         final int columnWidthSinceLastRun = column - lastRunStartColumn;

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -99,6 +99,7 @@ public final class TerminalRenderer {
 
             // Recycle RectF to avoid allocations in loop
             RectF reusableRect = new RectF();
+            Rect reusableSourceRect = new Rect();
 
             for (int column = 0; column < columns; ) {
                 final char charAtIndex = line[currentCharIndex];
@@ -112,7 +113,8 @@ public final class TerminalRenderer {
                         float left = column * mFontWidth;
                         float top = heightOffset - mFontLineSpacing;
                         reusableRect.set(left, top, left + mFontWidth, top + mFontLineSpacing);
-                        canvas.drawBitmap(bm, mEmulator.getScreen().getSixelRect(codePoint, style), reusableRect, null);
+                        mEmulator.getScreen().getSixelRect(style, reusableSourceRect);
+                        canvas.drawBitmap(bm, reusableSourceRect, reusableRect, null);
                     }
                     column += 1;
                     measuredWidthForRun = 0.f;

--- a/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
+++ b/terminal-view/src/main/java/com/termux/view/TerminalRenderer.java
@@ -97,6 +97,9 @@ public final class TerminalRenderer {
             int currentCharIndex = 0;
             float measuredWidthForRun = 0.f;
 
+            // Recycle RectF to avoid allocations in loop
+            RectF reusableRect = new RectF();
+
             for (int column = 0; column < columns; ) {
                 final char charAtIndex = line[currentCharIndex];
                 final boolean charIsHighsurrogate = Character.isHighSurrogate(charAtIndex);
@@ -108,14 +111,14 @@ public final class TerminalRenderer {
                     if (bm != null) {
                         float left = column * mFontWidth;
                         float top = heightOffset - mFontLineSpacing;
-                        RectF r = new RectF(left, top, left + mFontWidth, top + mFontLineSpacing);
-                        canvas.drawBitmap(mEmulator.getScreen().getSixelBitmap(codePoint, style), mEmulator.getScreen().getSixelRect(codePoint, style), r, null);
+                        reusableRect.set(left, top, left + mFontWidth, top + mFontLineSpacing);
+                        canvas.drawBitmap(bm, mEmulator.getScreen().getSixelRect(codePoint, style), reusableRect, null);
                     }
                     column += 1;
                     measuredWidthForRun = 0.f;
                     lastRunStyle = 0;
                     lastRunInsideCursor = false;
-                    lastRunStartColumn = column + 1;
+                    lastRunStartColumn = column;
                     lastRunStartIndex = currentCharIndex;
                     lastRunFontWidthMismatch = false;
                     currentCharIndex += charsForCodePoint;


### PR DESCRIPTION
This pull request introduces support for bitmap and image rendering in the terminal emulator, including Sixel graphics, by adding new classes and extending the existing buffer, row, and style management to handle bitmap slices alongside text. The changes include memory management for images, bitmap-aware rendering, and new APIs for adding, retrieving, and cleaning up images.

**Major features and changes:**

### Bitmap and Image Support

* Added a new `TerminalBitmap` class to manage bitmap slices, including logic for decoding, resizing, and placing images within the terminal grid. This class handles both Sixel and general image data, and integrates with the terminal buffer.
* Introduced a new `WorkingTerminalBitmap` class to support Sixel graphics, including color mapping, dynamic resizing, and pixel placement as Sixel data is parsed.

### Terminal Buffer Enhancements

* Extended `TerminalBuffer` to manage a collection of bitmaps (`bitmaps`), track bitmap usage, and provide APIs for adding Sixel images (`sixelStart`, `sixelChar`, `sixelSetColor`, `sixelEnd`) and general images (`addImage`). Added logic to garbage collect unused bitmaps and retrieve bitmap slices for rendering. [[1]](diffhunk://#diff-35a4aa84d42dde836e3ea90d691f9d9ffce6d5b47fa939851de9559ad7f32df0R4-R12) [[2]](diffhunk://#diff-35a4aa84d42dde836e3ea90d691f9d9ffce6d5b47fa939851de9559ad7f32df0R32-R37) [[3]](diffhunk://#diff-35a4aa84d42dde836e3ea90d691f9d9ffce6d5b47fa939851de9559ad7f32df0R53-R55) [[4]](diffhunk://#diff-35a4aa84d42dde836e3ea90d691f9d9ffce6d5b47fa939851de9559ad7f32df0R422-R443) [[5]](diffhunk://#diff-35a4aa84d42dde836e3ea90d691f9d9ffce6d5b47fa939851de9559ad7f32df0R539-R625)

### Row and Style Management

* Updated `TerminalRow` to track if a row contains bitmap slices (`mHasBitmap`) for performance, and set this flag when a bitmap is assigned to a cell. [[1]](diffhunk://#diff-c30fc463190e43f021ac850d54bcd4356af92b5d2441bd75293b9fe01a37aa5bR52-R53) [[2]](diffhunk://#diff-c30fc463190e43f021ac850d54bcd4356af92b5d2441bd75293b9fe01a37aa5bR151) [[3]](diffhunk://#diff-c30fc463190e43f021ac850d54bcd4356af92b5d2441bd75293b9fe01a37aa5bR161-R164)
* Extended `TextStyle` to encode and decode bitmap slice metadata (bitmap number, X/Y position) into the style long, and to recognize bitmap cells. [[1]](diffhunk://#diff-4798618c08f9830a251672919e520271496f88c156d61eff8c478bfc7243beecR38-R39) [[2]](diffhunk://#diff-4798618c08f9830a251672919e520271496f88c156d61eff8c478bfc7243beecR92-R111)

### Rendering Integration

* Updated `TerminalRenderer` to import bitmap and rectangle classes, and to ensure cell sizing is set before rendering, preparing for bitmap-aware drawing. [[1]](diffhunk://#diff-d3b8e7eead1f2fcb9b342f6aa5cfaffc8921286af4025e71cf4c434c1380234aR3-R8) [[2]](diffhunk://#diff-d3b8e7eead1f2fcb9b342f6aa5cfaffc8921286af4025e71cf4c434c1380234aR71)

---

These changes collectively enable the terminal emulator to display images and Sixel graphics inline with text, manage their lifecycles, and render them efficiently.